### PR TITLE
CI: Add a Cygwin run to GitHub Actions

### DIFF
--- a/.ci/after_success.sh
+++ b/.ci/after_success.sh
@@ -3,7 +3,7 @@
 # gather the coverage data
 python3 -m pip install codecov
 if [[ $MATRIX_DOCKER ]]; then
-  coverage xml --ignore-errors
+  python3 -m coverage xml --ignore-errors
 else
-  coverage xml
+  python3 -m coverage xml
 fi

--- a/.ci/build_cygwin.sh
+++ b/.ci/build_cygwin.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+python3 -m coverage erase
+make clean
+CFLAGS="-coverage -Werror=implicit-function-declaration" python3 -m pip install -v --global-option="build_ext" .
+python3 selftest.py

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -13,17 +13,20 @@ aptget_update()
         return 1
     fi
 }
-aptget_update || aptget_update retry || aptget_update retry
+if [[ $(uname) != CYGWIN* ]]; then
+    aptget_update || aptget_update retry || aptget_update retry
+fi
 
 set -e
 
-sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
-                         ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
-                         cmake meson imagemagick libharfbuzz-dev libfribidi-dev
+if [[ $(uname) != CYGWIN* ]]; then
+    sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
+                             ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
+                             cmake meson imagemagick libharfbuzz-dev libfribidi-dev
+    python3 -m pip install --upgrade pip
+fi
 
-python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel
-PYTHONOPTIMIZE=0 python3 -m pip install cffi
 python3 -m pip install coverage
 python3 -m pip install defusedxml
 python3 -m pip install olefile
@@ -32,24 +35,30 @@ python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 python3 -m pip install test-image-results
-python3 -m pip install numpy
 
-# PyQt5 doesn't support PyPy3
-if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
-  # arm64, ppc64le, s390x CPUs:
-  # "ERROR: Could not find a version that satisfies the requirement pyqt5"
-    sudo apt-get -qq install libxcb-xinerama0 pyqt5-dev-tools
-    python3 -m pip install pyqt5
+if [[ $(uname) != CYGWIN* ]]; then
+    PYTHONOPTIMIZE=0 python3 -m pip install cffi
+    python3 -m pip install numpy
+
+    # PyQt5 doesn't support PyPy3
+    if [[ $GHA_PYTHON_VERSION == 3.* ]]; then
+      # arm64, ppc64le, s390x CPUs:
+      # "ERROR: Could not find a version that satisfies the requirement pyqt5"
+        sudo apt-get -qq install libxcb-xinerama0 pyqt5-dev-tools
+        python3 -m pip install pyqt5
+    fi
+
+    # webp
+    pushd depends && ./install_webp.sh && popd
+
+    # libimagequant
+    pushd depends && ./install_imagequant.sh && popd
+
+    # raqm
+    pushd depends && ./install_raqm.sh && popd
+
+    # extra test images
+    pushd depends && ./install_extra_test_images.sh && popd
+else
+    cd depends && ./install_extra_test_images.sh && cd ..
 fi
-
-# webp
-pushd depends && ./install_webp.sh && popd
-
-# libimagequant
-pushd depends && ./install_imagequant.sh && popd
-
-# raqm
-pushd depends && ./install_raqm.sh && popd
-
-# extra test images
-pushd depends && ./install_extra_test_images.sh && popd

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -8,6 +8,7 @@ pull_request_rules:
       - status-success=Docker Test Successful
       - status-success=Windows Test Successful
       - status-success=MinGW Test Successful
+      - status-success=Cygwin Test Successful
       - status-success=continuous-integration/appveyor/pr
     actions:
       merge:

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -79,3 +79,11 @@ jobs:
           C:\tools\cygwin\bin\uname -a
           C:\tools\cygwin\bin\python3.8 -m pip list
           C:\tools\cygwin\bin\python3.8 -m pip show --files Pillow
+
+  success:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Cygwin Test Successful
+    steps:
+      - name: Success
+        run: echo Cygwin Test Successful

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     name: Cygwin Python 3.8
 
     steps:

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -5,7 +5,15 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: windows-latest
-    name: Cygwin Python 3.8
+    strategy:
+      fail-fast: false
+      matrix:
+        python-minor-version: [7, 8]
+        architecture: ["x86", "x86_64"]
+
+    timeout-minutes: 30
+
+    name: Python 3.${{ matrix.python-minor-version }} ${{ matrix.architecture }}
 
     steps:
       - name: Fix line endings
@@ -18,12 +26,15 @@ jobs:
       - name: Install Cygwin
         uses: cygwin/cygwin-install-action@v1
         with:
-          platform: x86_64
+          platform: ${{ matrix.architecture }}
           packages: >
-            ImageMagick python38-cffi python38-numpy python38-sip
-            python38-devel python38-tkinter ghostscript libfreetype-devel
-            libimagequant-devel libjpeg-devel liblcms2-devel libopenjp2-devel
-            libraqm-devel libtiff-devel libwebp-devel libxcb-devel
+            ImageMagick python3${{ matrix.python-minor-version }}-cffi
+            python3${{ matrix.python-minor-version }}-devel
+            python3${{ matrix.python-minor-version }}-numpy
+            python3${{ matrix.python-minor-version }}-sip
+            python3${{ matrix.python-minor-version }}-tkinter ghostscript
+            libfreetype-devel libimagequant-devel libjpeg-devel liblcms2-devel
+            libopenjp2-devel libraqm-devel libtiff-devel libwebp-devel libxcb-devel
             libxcb-xinerama0 qt5-devel-tools xorg-server-extra zlib-devel
 
       - name: Build system information
@@ -60,7 +71,7 @@ jobs:
         with:
           file: ./coverage.xml
           flags: GHA_Cygwin
-          name: ${{ runner.os }} Cygwin Python 3.8 ${{ matrix.architecture }}
+          name: Cygwin Python 3.${{ matrix.python-minor-version }} ${{ matrix.architecture }}
 
       - name: After failure
         if: failure()

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -62,6 +62,18 @@ jobs:
         run: |
           bash.exe xvfb-run -s '-screen 0 1024x768x24' .ci/test.sh
 
+      - name: Prepare to upload errors
+        if: failure()
+        run: |
+          mkdir -p Tests/errors
+
+      - name: Upload errors
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: errors
+          path: Tests/errors
+
       - name: After success
         run: |
           bash.exe .ci/after_success.sh
@@ -72,13 +84,6 @@ jobs:
           file: ./coverage.xml
           flags: GHA_Cygwin
           name: Cygwin Python 3.${{ matrix.python-minor-version }} ${{ matrix.architecture }}
-
-      - name: After failure
-        if: failure()
-        run: |
-          C:\tools\cygwin\bin\uname -a
-          C:\tools\cygwin\bin\python3.8 -m pip list
-          C:\tools\cygwin\bin\python3.8 -m pip show --files Pillow
 
   success:
     needs: build

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -41,24 +41,15 @@ jobs:
         run: |
           bash.exe -c "python3 .github/workflows/system-info.py"
 
-      - name: Ensure Python dependencies are installed
+      - name: Install dependencies
         run: |
-          bash.exe -c "python3 -m pip install pip wheel setuptools"
-          bash.exe -c "python3 -m pip install -r requirements.txt"
+          bash.exe .ci/install.sh
 
-      - name: Download extra test images
+      - name: Build
         run: |
-          bash.exe -c "cd depends; dash install_extra_test_images.sh"
+          bash.exe .ci/build_cygwin.sh
 
-      - name: Build Pillow
-        run: |
-          bash.exe -c "python3 setup.py bdist_wheel"
-
-      - name: Install Pillow
-        run: |
-          bash.exe -c "python3 -m pip install dist/*.whl"
-
-      - name: Test Pillow
+      - name: Test
         run: |
           bash.exe xvfb-run -s '-screen 0 1024x768x24' .ci/test.sh
 

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -8,73 +8,52 @@ jobs:
     name: Cygwin Python 3.8
 
     steps:
+      - name: Fix line endings
+        run: |
+          git config --global core.autocrlf input
+
       - name: Checkout Pillow
         uses: actions/checkout@v2
 
-      - name: Set up Cygwin
-        uses: egor-tensin/setup-cygwin@v3
+      - name: Install Cygwin
+        uses: cygwin/cygwin-install-action@v1
         with:
-          platform: x64
+          platform: x86_64
           packages: >
-            libfreetype-devel libimagequant-devel libjpeg-devel
-            liblcms2-devel libopenjp2-devel libraqm-devel
-            libtiff-devel libwebp-devel libxcb-devel libpng-devel
-            ImageMagick jpeg netpbm perl xorg-server-extra
-            xorg-server-common xinit subversion python38-setuptools
-            python38-devel python38-tkinter python38-wheel
-            python38-pip python38-olefile python38-numpy
-            python38-pytest python38-sphinx python38-packaging
-            python38-cffi python38-requests
-          install-dir: 'C:\tools\cygwin'
-
-      - name: Clean up path
-        uses: egor-tensin/cleanup-path@v2
-        with:
-          dirs: 'C:\tools\cygwin\bin;C:\tools\cygwin\lib\lapack'
+            ImageMagick python38-cffi python38-numpy python38-sip
+            python38-devel python38-tkinter ghostscript libfreetype-devel
+            libimagequant-devel libjpeg-devel liblcms2-devel libopenjp2-devel
+            libraqm-devel libtiff-devel libwebp-devel libxcb-devel
+            libxcb-xinerama0 qt5-devel-tools xorg-server-extra zlib-devel
 
       - name: Build system information
-        run: C:\tools\cygwin\bin\python3.8 .github/workflows/system-info.py
+        run: |
+          bash.exe -c "python3 .github/workflows/system-info.py"
 
       - name: Ensure Python dependencies are installed
         run: |
-          C:\tools\cygwin\bin\python3.8 -m pip install pip wheel setuptools
-          C:\tools\cygwin\bin\python3.8 -m pip install -r requirements.txt
-          C:\tools\cygwin\bin\python3.8 -m pip install pytest-forked
+          bash.exe -c "python3 -m pip install pip wheel setuptools"
+          bash.exe -c "python3 -m pip install -r requirements.txt"
 
       - name: Download extra test images
         run: |
-          C:\tools\cygwin\bin\dash -c "tr -d '\r' <depends/install_extra_test_images.sh >install_extra_test_images.sh"
-          C:\tools\cygwin\bin\dash -c "mv install_extra_test_images.sh depends/install_extra_test_images.sh"
-          C:\tools\cygwin\bin\dash -c "cd depends; dash install_extra_test_images.sh"
+          bash.exe -c "cd depends; dash install_extra_test_images.sh"
 
       - name: Build Pillow
         run: |
-          C:\tools\cygwin\bin\python3.8 setup.py bdist_wheel
+          bash.exe -c "python3 setup.py bdist_wheel"
 
       - name: Install Pillow
         run: |
-          C:\tools\cygwin\bin\dash -c '/usr/bin/python3.8 -m pip install dist/*.whl'
-
-      - name: Check Pillow configuration
-        run: |
-          C:\tools\cygwin\bin\python3.8 selftest.py
+          bash.exe -c "python3 -m pip install dist/*.whl"
 
       - name: Test Pillow
         run: |
-          C:\tools\cygwin\bin\mv .ci/test.sh .ci/test.sh.dos
-          C:\tools\cygwin\bin\dash -c "/bin/tr -d '\r' <.ci/test.sh.dos >.ci/test.sh"
-          C:\tools\cygwin\bin\chmod u+x .ci/test.sh
-          C:\tools\cygwin\bin\dash /usr/bin/xvfb-run -s '-screen 0 1024x768x24' .ci/test.sh .8 --ignore=Tests/test_numpy.py
-
-      - name: Test the possibly-segfaulting NumPy tests separately
-        run: |
-          C:\tools\cygwin\bin\python3.8 -m pytest --forked Tests/test_numpy.py -k roundtrip
+          bash.exe xvfb-run -s '-screen 0 1024x768x24' .ci/test.sh
 
       - name: After success
         run: |
-          C:\tools\cygwin\bin\mv .ci/after_success.sh .ci/after_success.sh.dos
-          C:\tools\cygwin\bin\dash -c "tr -d '\r' <.ci/after_success.sh.dos >.ci/after_success.sh"
-          C:\tools\cygwin\bin\bash .ci/after_success.sh
+          bash.exe .ci/after_success.sh
 
       - name: Upload coverage
         uses: codecov/codecov-action@v2

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           platform: ${{ matrix.architecture }}
           packages: >
-            ImageMagick python3${{ matrix.python-minor-version }}-cffi
+            ImageMagick jpeg python3${{ matrix.python-minor-version }}-cffi
             python3${{ matrix.python-minor-version }}-devel
             python3${{ matrix.python-minor-version }}-numpy
             python3${{ matrix.python-minor-version }}-sip


### PR DESCRIPTION
Various suggestions for https://github.com/python-pillow/Pillow/pull/5878

- Switched to windows-latest, like https://github.com/python-pillow/Pillow/pull/5999
- Switch to https://github.com/cygwin/cygwin-install-action - it would seem to be the official action for this
- Added a testing matrix, so that other Python versions can be tested, and also 32-bit
- Connected these jobs to mergify, for when we use automerge - https://mergify.com/features/auto-merge
- Upload errors on failure, like elsewhere - https://github.com/python-pillow/Pillow/blob/8e3878dec2b300f5b495dd81989a77089747abee/.github/workflows/test.yml#L81-L91
- Install Pillow directly, rather than building a wheel

However, as with the current state of your PR, numpy is a problem. Here, it prevents one of the builds from finishing.