### PR TITLE
Do not install NumPy on Python 3.11

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -35,12 +35,11 @@ python3 -m pip install -U pytest-cov
 python3 -m pip install -U pytest-timeout
 python3 -m pip install pyroma
 python3 -m pip install test-image-results
-# TODO Remove condition when NumPy supports 3.11
-if ! [ "$GHA_PYTHON_VERSION" == "3.11-dev" ]; then python3 -m pip install numpy ; fi
 
 if [[ $(uname) != CYGWIN* ]]; then
     PYTHONOPTIMIZE=0 python3 -m pip install cffi
-    python3 -m pip install numpy
+    # TODO Remove condition when NumPy supports 3.11
+    if ! [ "$GHA_PYTHON_VERSION" == "3.11-dev" ]; then python3 -m pip install numpy ; fi
 
     # PyQt6 doesn't support PyPy3
     if [[ $GHA_PYTHON_VERSION == 3.* ]]; then


### PR DESCRIPTION
This should fix the failing Python 3.11 job in https://github.com/python-pillow/Pillow/pull/5878