### PR TITLE
CI: Use alternatives to select python version

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -25,6 +25,7 @@ if [[ $(uname) != CYGWIN* ]]; then
                              cmake meson imagemagick libharfbuzz-dev libfribidi-dev
 fi
 
+uname -mo
 if [[ $(uname -mo) != "i*86 Cygwin" ]]; then
     python3 -m pip install --upgrade pip
 fi

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -25,7 +25,6 @@ if [[ $(uname) != CYGWIN* ]]; then
                              cmake meson imagemagick libharfbuzz-dev libfribidi-dev
 fi
 
-uname -mo
 if [[ $(uname -mo) != i*86" Cygwin" ]]; then
     python3 -m pip install --upgrade pip
 fi

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -26,7 +26,7 @@ if [[ $(uname) != CYGWIN* ]]; then
 fi
 
 uname -mo
-if [[ $(uname -mo) != "i*86 Cygwin" ]]; then
+if [[ $(uname -mo) != i*86" Cygwin" ]]; then
     python3 -m pip install --upgrade pip
 fi
 

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -57,10 +57,10 @@ jobs:
       - name: Ensure correct python minor version used in scripts
         shell: bash.exe -eo pipefail -o igncr "{0}"
         run: |
-          alternatives --set python3 /usr/bin/python3.${{ matrix.python-minor-version }}
-          alternatives --display python3
-          alternatives --set python /usr/bin/python3.${{ matrix.python-minor-version }}
-          alternatives --display python
+          /usr/sbin/alternatives --set python3 /usr/bin/python3.${{ matrix.python-minor-version }}
+          /usr/sbin/alternatives --display python3
+          /usr/sbin/alternatives --set python /usr/bin/python3.${{ matrix.python-minor-version }}
+          /usr/sbin/alternatives --display python
 
       - name: Build system information
         run: |

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -53,34 +53,42 @@ jobs:
           key: ${{ runner.os }}-cygwin-${{ matrix.architecture }}-pip3.${{ matrix.python-minor-version }}-${{ hashFiles('.ci/install.sh') }}
           restore-keys: |
             ${{ runner.os }}-cygwin-${{ matrix.architecture }}-pip3.${{ matrix.python-minor-version }}-
+            
+      - name: Ensure correct python minor version used in scripts
+        shell: bash.exe -eo pipefail -o igncr "{0}"
+        run: |
+          alternatives --set python3 /usr/bin/python3.${{ matrix.python-minor-version }}
+          alternatives --display python3
+          alternatives --set python /usr/bin/python3.${{ matrix.python-minor-version }}
+          alternatives --display python
 
       - name: Build system information
         run: |
-          dash.exe -c "python3.${{ matrix.python-minor-version }} .github/workflows/system-info.py"
+          dash.exe -c "python3 .github/workflows/system-info.py"
 
       - name: Install dependencies
         run: |
-          dash.exe -c "python3.${{ matrix.python-minor-version }} -m pip install -U pip"
+          dash.exe -c "python3 -m pip install -U pip"
           bash.exe .ci/install.sh
 
       - name: Install a different NumPy
         if: matrix.architecture == 'x86_64'
         shell: dash.exe -l "{0}"
         run: |
-          python3.${{ matrix.python-minor-version }} -m pip install -U 'numpy!=1.21.*'
+          python3 -m pip install -U 'numpy!=1.21.*'
 
       - name: Check imports
         shell: dash.exe -l "{0}"
         run: |
-          python3.${{ matrix.python-minor-version }} -c 'import numpy as np; print(np.__version__)'
+          python3 -c 'import numpy as np; print(np.__version__)'
 
       - name: Build
         shell: bash.exe -eo pipefail -o igncr "{0}"
         run: |
-          python3.${{ matrix.python-minor-version }} -m coverage erase
+          python3 -m coverage erase
           make clean
-          CFLAGS="-coverage -Werror=implicit-function-declaration" python3.${{ matrix.python-minor-version }} -m pip install -v --global-option="build_ext" .
-          python3.${{ matrix.python-minor-version }} selftest.py
+          CFLAGS="-coverage -Werror=implicit-function-declaration" python3 -m pip install -v --global-option="build_ext" .
+          python3 selftest.py
 
       - name: Rebase dlls
         shell: bash.exe -eo pipefail -o igncr "{0}"


### PR DESCRIPTION
Instead of specifying `python3.${{ matrix.python-minor-version }}` every time, set `alternatives` so that `python3` and `python` are `python3.{7,8,9}` in turn.