### PR TITLE
BLD: Try to adapt library finder for Cygwin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -643,6 +643,8 @@ class pil_build_ext(build_ext):
                     feature.jpeg = "jpeg"
                 elif sys.platform == "win32" and _find_library_file(self, "libjpeg"):
                     feature.jpeg = "libjpeg"  # alternative name
+                elif sys.platform == "cygwin" and _find_library_file(self, "libjpeg.dll"):
+                    feature.jpeg = "jpeg"
 
         feature.openjpeg_version = None
         if feature.want("jpeg2000"):


### PR DESCRIPTION
The pattern is `lib${name}.dll.a` for just about anything.  For example, `libjpeg.dll.a`

Fixes python-pillow/pillow#6216.

Changes proposed in this pull request:

 * Use the Cygwin import library naming pattern for finding import libraries on Cygwin