### PR TITLE
CI: Update Cygwin pip, but not on 32-bit

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -24,6 +24,10 @@ if [[ $(uname) != CYGWIN* ]]; then
                              ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
                              cmake meson imagemagick libharfbuzz-dev libfribidi-dev
     python3 -m pip install --upgrade pip
+elif [[ $(uname -m) != i*86 ]]; then
+    python3 -m pip install --upgrade pip
+else
+    python3 -m pip install --upgrade 'pip<22'
 fi
 
 python3 -m pip install --upgrade wheel

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -23,8 +23,9 @@ if [[ $(uname) != CYGWIN* ]]; then
     sudo apt-get -qq install libfreetype6-dev liblcms2-dev python3-tk\
                              ghostscript libffi-dev libjpeg-turbo-progs libopenjp2-7-dev\
                              cmake meson imagemagick libharfbuzz-dev libfribidi-dev
-    python3 -m pip install --upgrade pip
-elif [[ $(uname -m) != i*86 ]]; then
+fi
+
+if [[ $(uname -mo) != "i*86 Cygwin" ]]; then
     python3 -m pip install --upgrade pip
 else
     python3 -m pip install --upgrade 'pip<22'

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -27,8 +27,6 @@ fi
 
 if [[ $(uname -mo) != "i*86 Cygwin" ]]; then
     python3 -m pip install --upgrade pip
-else
-    python3 -m pip install --upgrade 'pip<22'
 fi
 
 python3 -m pip install --upgrade wheel

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -60,7 +60,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          dash.exe -c "python3.${{ matrix.python-minor-version }} -m pip install -U pip"
           bash.exe .ci/install.sh
 
       - name: Install a different NumPy


### PR DESCRIPTION
32-bit Cygwin pip>=22 fails to install coverage.

Changes proposed in this pull request:

 * Update Cygwin pip in .ci/install.sh
