### PR TITLE
Added Cygwin badge

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-coverage erase
+python3 -m coverage erase
 if [ $(uname) == "Darwin" ]; then
     export CPPFLAGS="-I/usr/local/miniconda/include";
 fi

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -27,6 +27,7 @@ fi
 
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade wheel
+PYTHONOPTIMIZE=0 python3 -m pip install cffi
 python3 -m pip install coverage
 python3 -m pip install defusedxml
 python3 -m pip install olefile
@@ -37,7 +38,6 @@ python3 -m pip install pyroma
 python3 -m pip install test-image-results
 
 if [[ $(uname) != CYGWIN* ]]; then
-    PYTHONOPTIMIZE=0 python3 -m pip install cffi
     # TODO Remove condition when NumPy supports 3.11
     if ! [ "$GHA_PYTHON_VERSION" == "3.11-dev" ]; then python3 -m pip install numpy ; fi
 

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -69,10 +69,7 @@ jobs:
       - name: Build
         shell: bash.exe -eo pipefail -o igncr "{0}"
         run: |
-          python3 -m coverage erase
-          make clean
-          CFLAGS="-coverage -Werror=implicit-function-declaration" python3 -m pip install -v --global-option="build_ext" .
-          python3 selftest.py
+          bash.exe .ci/build.sh
 
       - name: Test
         run: |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ As of 2019, Pillow development is
             <a href="https://github.com/python-pillow/Pillow/actions/workflows/test-mingw.yml"><img
                 alt="GitHub Actions build status (Test MinGW)"
                 src="https://github.com/python-pillow/Pillow/workflows/Test%20MinGW/badge.svg"></a>
+            <a href="https://github.com/python-pillow/Pillow/actions/workflows/test-cygwin.yml"><img
+                alt="GitHub Actions build status (Test Cygwin)"
+                src="https://github.com/python-pillow/Pillow/workflows/Test%20Cygwin/badge.svg"></a>
             <a href="https://github.com/python-pillow/Pillow/actions/workflows/test-docker.yml"><img
                 alt="GitHub Actions build status (Test Docker)"
                 src="https://github.com/python-pillow/Pillow/workflows/Test%20Docker/badge.svg"></a>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,10 @@ Pillow for enterprise is available via the Tidelift Subscription. `Learn more <h
    :target: https://github.com/python-pillow/Pillow/actions/workflows/test-mingw.yml
    :alt: GitHub Actions build status (Test MinGW)
 
+.. image:: https://github.com/python-pillow/Pillow/workflows/Test%20Cygwin/badge.svg
+   :target: https://github.com/python-pillow/Pillow/actions/workflows/test-cygwin.yml
+   :alt: GitHub Actions build status (Test Cygwin)
+
 .. image:: https://img.shields.io/appveyor/build/python-pillow/Pillow/main.svg?label=Windows%20build
    :target: https://ci.appveyor.com/project/python-pillow/Pillow
    :alt: AppVeyor CI build status (Windows)


### PR DESCRIPTION
Three changes for https://github.com/python-pillow/Pillow/pull/5878

1. Adds a Cygwin badge to the README and the docs
2. I've discovered you can just use build.sh directly now
3. I've found you can install cffi now